### PR TITLE
Use `=` to avoid NSE note

### DIFF
--- a/R/figure2rmd.R
+++ b/R/figure2rmd.R
@@ -36,7 +36,7 @@ figure2rmd <- function(text
                       gsub("\\{\\#fig\\:|\\}", "",.) %>% gsub("\\.", "", .)
       ) %>% 
       dplyr::select(!c(.data$value, .data$info)) %>% 
-      dplyr::mutate(id := "figure") %>% 
+      dplyr::mutate(id = "figure") %>% 
       dplyr::mutate(across(everything(), as.character)) %>% 
       tidyr::pivot_longer(!.data$id) %>% 
       dplyr::select(!.data$id) %>% 

--- a/R/table2rmd.R
+++ b/R/table2rmd.R
@@ -33,7 +33,7 @@ table2rmd <- function(text
                       gsub("\\{\\#tbl\\:|\\}", "",.) %>% gsub("\\.", "", .)
       ) %>% 
       dplyr::select(!c(.data$value)) %>% 
-      dplyr::mutate(id := "table") %>% 
+      dplyr::mutate(id = "table") %>% 
       dplyr::mutate(across(everything(), as.character)) %>% 
       tidyr::pivot_longer(!.data$id) %>% 
       dplyr::select(!.data$id) %>% 


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

Your package does one of two things:

- It re-exports `dplyr::id()`, which has been defunct for many years and has now been removed from dplyr.

- It references a column named `id`, likely in a `mutate()` or `summarise()`, but does not note this as a global variable with `utils::globalVariables("id")`. In this case, you got lucky that dplyr exported `id()`, meaning that you did not need a global variable for `"id"`. Since we have removed `dplyr::id()`, your package will need this now.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!